### PR TITLE
Add docker for production backend

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+.git
+*.md
+.gitignore

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,21 @@
+# get the base node.js image
+FROM node:14-alpine
+
+# set the working dir for container
+WORKDIR /server
+
+# copy the json file first
+COPY package*.json ./
+
+# install npm dependencies
+RUN npm install
+
+# copy other project files
+COPY . .
+
+# expose port 5000
+EXPOSE 5000
+
+# start the server
+CMD ["npm", "start"]
+ 

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: sjsu-tt-backend
+    container_name: sjsu-tt-express-server
+    environment:
+      - NODE_ENV=production
+    restart: always
+    ports:
+      - '5000:5000'
+    depends_on:
+      - mongodb
+    networks:
+      - sjsu-tt-backend-network
+  mongodb:
+    # pulls mongodb base docker image
+    image: mongo
+    container_name: mongodb-container
+    # binds ~/data/db path in host system's HDD to /data/db in container
+    volumes:
+      - ~/data/db:/data/db
+    ports:
+      - '27017:27017'
+    networks:
+      - sjsu-tt-backend-network
+
+networks:
+  sjsu-tt-backend-network:
+    driver: bridge

--- a/server/routes/api/services/upload-s3.js
+++ b/server/routes/api/services/upload-s3.js
@@ -19,9 +19,13 @@ const fileFilter = (req, file, callback) => {
 };
 
 // Middleware that parses 'imageFile' field in request body
-const fileMiddleware = multer({ storage, fileFilter, limits: {
-	fileSize: 1024 * 1024 * 5 // 5MB max file size
-} }).single('imageFile');
+const fileMiddleware = multer({
+  storage,
+  fileFilter,
+  limits: {
+    fileSize: 1024 * 1024 * 5, // 5MB max file size
+  },
+}).single('imageFile');
 
 /**
  * Uploads to an S3 bucket

--- a/server/server.js
+++ b/server/server.js
@@ -34,6 +34,17 @@ if (process.env.NODE_ENV === 'development') {
     .catch((error) => {
       throw new Error(error);
     });
+} else if (process.env.NODE_ENV === 'production') {
+  mongoose
+    .connect('mongodb://mongodb-container:27017/sjsu-tt-database', {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      useCreateIndex: true,
+    })
+    .then(() => console.log('Production mode: Connected to MongoDB container'))
+    .catch((error) => {
+      throw new Error(error);
+    });
 }
 
 // Passport.js config (JWT extraction from request headers)


### PR DESCRIPTION
This change adds a `docker-compose.yml` file that will allow the backend to be spun up easily on any virtual machine. It spins up a base MongoDB image and puts it in a container-to-container network with the Express API. It also maps all MongoDB data to an absolute path on the host system for data persistence.