### PR TITLE
Add Content-Type & Content-Disposition headers to S3 putObject

### DIFF
--- a/server/routes/api/brothers/brothers.controller.js
+++ b/server/routes/api/brothers/brothers.controller.js
@@ -68,7 +68,12 @@ brotherController.post('/register', fileMiddleware, async (req, res) => {
     let fileExtension = req.file.originalname.split('.');
     fileExtension = fileExtension[fileExtension.length - 1];
     const filePath = `${req.body.pledgeClass}/${req.body.studentID}.${fileExtension}`;
-    await uploadToS3('brother-headshots', filePath, req.file.buffer);
+    await uploadToS3(
+      'brother-headshots',
+      filePath,
+      req.file.buffer,
+      req.file.mimetype
+    );
 
     const newBrother = new Brother({
       name: req.body.name,

--- a/server/routes/api/services/upload-s3.js
+++ b/server/routes/api/services/upload-s3.js
@@ -31,13 +31,17 @@ const fileMiddleware = multer({
  * Uploads to an S3 bucket
  * @param {*} bucketName name of bucket
  * @param {*} key name of file
- * @param {*} buffer the file
+ * @param {*} buffer the file in memory
+ * @param {*} mimetype the mime type of the file
  */
-const uploadToS3 = async (bucketName, key, buffer) => {
+const uploadToS3 = async (bucketName, key, buffer, mimetype) => {
   const uploadParams = {
     Bucket: bucketName,
     Key: key,
     Body: buffer,
+    ContentType: mimetype,
+    ContentDisposition: 'inline',
+    ACL: 'public-read',
   };
 
   const putResult = S3.putObject(uploadParams).promise();


### PR DESCRIPTION
Adds `Content-Type` and `Content-Disposition` headers to S3 `putObject` parameters to allow media to be displayed in browser rather than being forced to download when opening Object URL