### PR TITLE
Fix PrivateRoute component

### DIFF
--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,14 +1,19 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { navigate } from 'gatsby';
 import PropTypes from 'prop-types';
 
 // eslint-disable-next-line react/prop-types
 const PrivateRoute = ({ component: Component, auth, ...rest }) => {
-  if (!auth.isAuthenticated) {
-    navigate('/portal/login');
-    return null;
-  }
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    if (!hasMounted) {
+      setHasMounted(true);
+    } else if (!auth.isAuthenticated) {
+      navigate('/portal/login');
+    }
+  }, [hasMounted, auth.isAuthenticated]);
 
   // eslint-disable-next-line react/jsx-props-no-spreading
   return <Component {...rest} />;

--- a/frontend/src/pages/portal.jsx
+++ b/frontend/src/pages/portal.jsx
@@ -24,9 +24,6 @@ const Portal = () => {
       <Sample path="/sample" />
       <Sample path="/sample/:resultsAmount" />
       <Login path="/login" />
-      <Dashboard path="/dashboard" />
-      <Register path="/register" />
-      <Edit path="/edit" />
       <PrivateRoute path="/dashboard" component={Dashboard} />
       <PrivateRoute path="/register" component={Register} />
       <PrivateRoute path="/edit" component={Edit} />


### PR DESCRIPTION
This change adds `useEffect` hook to the `PrivateRoute` component to wait for the component to mount to DOM before evaluating Redux state for authentication. It also uses `hasMounted` boolean trigger to "buffer" while Redux dispatches global props.

i.e., when useEffect is first ran, `auth.isAuthenticated` will be false initially, so users would be redirected to login even when they are actually authenticated. Redux dispatches the state after `auth.isAuthenticated` is evaluated, so the redirect would have already happened. `hasMounted` boolean remedies this