### PR TITLE
Remove brotherId from API endpoint URLs

### DIFF
--- a/frontend/src/pages/portal_pages/dashboard.jsx
+++ b/frontend/src/pages/portal_pages/dashboard.jsx
@@ -143,9 +143,7 @@ const Dashboard = (props) => {
 
   const fetchBrotherData = async () => {
     try {
-      const apiResponse = await axios.get(
-        `/api/brothers/dashboard/${props.auth.user.id}`
-      );
+      const apiResponse = await axios.get('/api/brothers/me/dashboard');
       setBrotherData(apiResponse.data);
     } catch (error) {
       setFetchError(true);

--- a/frontend/src/pages/portal_pages/edit.jsx
+++ b/frontend/src/pages/portal_pages/edit.jsx
@@ -67,9 +67,7 @@ const Edit = (props) => {
 
   const assignInputValues = async () => {
     try {
-      const apiResponse = await axios.get(
-        `/api/brothers/edit/${props.auth.user.id}`
-      );
+      const apiResponse = await axios.get('/api/brothers/me/edit');
 
       // Cache current state for client-side validation
       setCurrentBrotherData(apiResponse.data);

--- a/server/routes/api/brothers/brothers.controller.js
+++ b/server/routes/api/brothers/brothers.controller.js
@@ -35,23 +35,36 @@ brotherController.get(
 );
 
 /**
- * GET Endpoint for dashboard (one brother)
- * @route GET api/brothers/dashboard/:brotherId
- * @desc retrieve all info about brother with brotherId
+ * GET Endpoint (one brother)
+ * @route GET api/brothers/me/:page
+ * @desc retrieve all info needed about brother depending on what page
  */
 brotherController.get(
-  '/dashboard/:brotherId',
+  '/me/:page',
+  // passport.authenticate() validates the JWT in request header and gives req.user object
   passport.authenticate('jwt', { session: false }),
   (req, res) => {
-    const { brotherId } = req.params;
+    const { page } = req.params;
+    console.log(req.user);
 
-    Brother.findById(brotherId, (error, brother) => {
-      if (error) {
-        return res.status(404).json({ message: `No brother found: ${error}` });
-      }
-
-      res.status(200).json(brother);
-    });
+    // Respond with only needed fields for the page
+    let responseObject;
+    switch (page) {
+      case 'dashboard':
+        responseObject = req.user;
+        break;
+      case 'edit':
+        responseObject = {
+          email: req.user.email,
+          biography: req.user.biography,
+          major: req.user.major,
+          graduatingYear: req.user.graduatingYear,
+        };
+        break;
+      default:
+        console.error(`Unknown page parameter passed, ${page}`);
+    }
+    res.status(200).json(responseObject);
   }
 );
 
@@ -190,32 +203,6 @@ brotherController.put(
       foundBrother.save();
 
       res.status(200).json(foundBrother);
-    });
-  }
-);
-
-/**
- * GET Endpoint for edit form (one brother)
- * @route GET api/brothers/edit/:brotherId
- * @desc retrieve specific form info about brother with brotherId
- */
-brotherController.get(
-  '/edit/:brotherId',
-  passport.authenticate('jwt', { session: false }),
-  (req, res) => {
-    const { brotherId } = req.params;
-
-    Brother.findById(brotherId, (error, brother) => {
-      if (error) {
-        return res.status(404).json({ message: `No brother found: ${error}` });
-      }
-
-      res.status(200).json({
-        email: brother.email,
-        biography: brother.biography,
-        major: brother.major,
-        graduatingYear: brother.graduatingYear,
-      });
     });
   }
 );


### PR DESCRIPTION
Removes `:brotherId` from API endpoint URLs on the backend, and uses the ID from the JWT in the Authorization header that is sent with every request. This improves the app in 2 ways:

* Doesn't need to perform a redundant lookup in MongoDB since passport middleware does that on every secure endpoint to ensure the JWT is legit and actually maps to en existing user
* Attack vector is a bit smaller now, GET endpoints are suffixed with `/me` to indicate the endpoint works for only the user associated with the token in the request header. Attackers now can't abuse the `:brotherId` parameter in the URL. 
  * Succinct [post](https://softwareengineering.stackexchange.com/questions/362060/should-id-be-given-in-url-if-already-secured-with-jwt-containing-id) explaining the benefits of this change from a security standpoint