### PR TITLE
Remove brotherId from PUT endpoint

### DIFF
--- a/frontend/src/redux/actions/authActions.js
+++ b/frontend/src/redux/actions/authActions.js
@@ -90,7 +90,7 @@ export const editBrother = (brotherId, brotherName, editedFields) => (
   dispatch
 ) => {
   axios
-    .put(`/api/brothers/${brotherId}`, editedFields)
+    .put('/api/brothers/me', editedFields)
     .then((response) => {
       console.log(response);
       dispatch(updateEditSuccessMessage(brotherName));


### PR DESCRIPTION
Forgot to remove `brotherId` for PUT endpoint for edit form, same idea as #71 . Uses the `req.user` object that passport middleware provides after verifying JWT to directly modify the fields and save