### PR TITLE
Add phone number and isGraduated fields to Brother schema

### DIFF
--- a/frontend/src/pages/portal_pages/register.jsx
+++ b/frontend/src/pages/portal_pages/register.jsx
@@ -17,10 +17,12 @@ const Register = (props) => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [studentID, setStudentID] = useState('');
+  const [phoneNumber, setPhoneNumber] = useState(-1);
   const [major, setMajor] = useState('Aerospace Engineering');
   const [graduatingYear, setGraduatingYear] = useState(-1);
   const [pledgeClass, setPledgeClass] = useState('Alpha');
   const [position, setPosition] = useState('Member');
+  const [isGraduated, setIsGraduated] = useState(false);
   const [imageFile, setImageFile] = useState('');
   const [wasRegistered, setWasRegistered] = useState(false);
   const [registeredBrother, setRegisteredBrother] = useState('');
@@ -51,6 +53,9 @@ const Register = (props) => {
       case 'studentID':
         setStudentID(event.target.value);
         break;
+      case 'phoneNumber':
+        setPhoneNumber(event.target.value);
+        break;
       case 'major':
         setMajor(event.target.value);
         break;
@@ -62,6 +67,9 @@ const Register = (props) => {
         break;
       case 'position':
         setPosition(event.target.value);
+        break;
+      case 'isGraduated':
+        setIsGraduated(!isGraduated);
         break;
       default:
         console.error('Unknown input ID');
@@ -80,10 +88,12 @@ const Register = (props) => {
       name,
       email,
       studentID,
+      phoneNumber,
       major,
       graduatingYear,
       pledgeClass,
       position,
+      isGraduated,
       imageFile,
     };
 
@@ -149,7 +159,9 @@ const Register = (props) => {
                   <span className="invalid-feedback">{errors.email}</span>
                 </div>
                 <div className="form-group">
-                  <label htmlFor="studentID">Student ID</label>
+                  <label htmlFor="studentID">
+                    Student ID (leave empty if Alumni)
+                  </label>
                   <input
                     type="number"
                     id="studentID"
@@ -161,6 +173,20 @@ const Register = (props) => {
                     })}
                   />
                   <span className="invalid-feedback">{errors.studentID}</span>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="phoneNumber">Phone Number</label>
+                  <input
+                    type="number"
+                    id="phoneNumber"
+                    placeholder="Enter phone number (Numeric values only)"
+                    onChange={(event) => handleChange(event)}
+                    error={errors.phoneNumber}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.phoneNumber,
+                    })}
+                  />
+                  <span className="invalid-feedback">{errors.phoneNumber}</span>
                 </div>
                 <div className="form-group">
                   <label htmlFor="major">Major</label>
@@ -231,6 +257,19 @@ const Register = (props) => {
                   <span className="invalid-feedback">{errors.position}</span>
                 </div>
                 <div className="form-group">
+                  <div className="form-check pl-0">
+                    <input
+                      type="checkbox"
+                      id="isGraduated"
+                      onChange={(event) => handleChange(event)}
+                      className="form-check-input"
+                    />
+                    <label htmlFor="isGraduated" className="form-check-label">
+                      Is Graduated?
+                    </label>
+                  </div>
+                </div>
+                <div className="form-group">
                   <label htmlFor="imageFile">Image</label>
                   <input
                     type="file"
@@ -239,7 +278,7 @@ const Register = (props) => {
                     className="form-control-file"
                   />
                 </div>
-                <button type="submit" className="btn btn-warning">
+                <button type="submit" className="btn btn-warning mt-3">
                   Submit
                 </button>
               </form>

--- a/server/routes/api/brothers/brother.js
+++ b/server/routes/api/brothers/brother.js
@@ -29,6 +29,10 @@ const BrotherSchema = new Schema({
   },
   studentID: {
     type: Number,
+    required: false, // e-board never kept track of student IDs :)))
+  },
+  phoneNumber: {
+    type: Number,
     required: true,
   },
   password: {
@@ -53,6 +57,10 @@ const BrotherSchema = new Schema({
     type: String,
     required: true,
     enum: Object.values(PositionEnum),
+  },
+  isGraduated: {
+    type: Boolean,
+    required: true,
   },
   biography: {
     type: String,

--- a/server/routes/api/util/form-validation/register.js
+++ b/server/routes/api/util/form-validation/register.js
@@ -35,12 +35,19 @@ function validateRegisterInput(requestBody) {
   } else if (!Validator.isEmail(data.email)) {
     errors.email = 'Email field must be valid';
   }
-  if (Validator.isEmpty(data.studentID)) {
-    errors.studentID = 'Student ID is required';
-  } else if (!Validator.isNumeric(data.studentID)) {
-    errors.studentID = 'Student ID must be a number';
-  } else if (!Validator.isLength(data.studentID, { min: 9, max: 9 })) {
-    errors.studentID = 'Student ID must be 9 characters';
+  if (!Validator.isEmpty(data.studentID)) {
+    if (!Validator.isNumeric(data.studentID)) {
+      errors.studentID = 'Student ID must be a number';
+    } else if (!Validator.isLength(data.studentID, { min: 9, max: 9 })) {
+      errors.studentID = 'Student ID must be 9 characters';
+    }
+  }
+  if (Validator.isEmpty(data.phoneNumber)) {
+    errors.phoneNumber = 'Phone number field is required';
+  } else if (!Validator.isNumeric(data.phoneNumber)) {
+    errors.phoneNumber = 'Phone number must be a number';
+  } else if (!Validator.isLength(data.phoneNumber, { min: 10, max: 10 })) {
+    errors.phoneNumber = 'Phone number must be 10 digits';
   }
   if (Validator.isEmpty(data.major)) {
     errors.major = 'Major field is required';


### PR DESCRIPTION
e-board never formally kept track of student IDs on the master roster (they would ask for our IDs but I guess they never recorded it officially ???) 😃

Because of this, `studentID` is now a non-required field in the schema. This change will also favor using `studentID` for unique image paths in S3, but if it is not present, then it will resort to using `phoneNumber` instead.

This change also adds `isGraduated` field to the schema. It will allow us to render actives by default on the main "Brothers" page