### PR TITLE
Add seedDB script, tweak enums/schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ yarn-error.log
 
 # super duper secret stuffs
 secrets.json
+actives.js

--- a/frontend/src/pages/portal_pages/dashboard.jsx
+++ b/frontend/src/pages/portal_pages/dashboard.jsx
@@ -7,10 +7,7 @@ import { logoutBrother } from '../../redux/actions/authActions';
 import Navbar from '../../components/NavBar';
 import dashboardStyles from './dashboard.module.scss';
 
-import {
-  PledgeClassEnum,
-  PositionEnum,
-} from '../../../../server/routes/api/util/enums/brother-enums';
+import { PledgeClassEnum, PositionEnum } from '../../util/enums/brother-enums';
 
 /**
  * Tells if the logged in user can view a TaskBar item with expectedPosition
@@ -56,7 +53,7 @@ const TaskBar = ({ pledgeClass, position, handleLogout }) => {
           </Link>
         </div>
       )}
-      {positionHasFeature(PledgeClassEnum.Webmaster, position) && (
+      {positionHasFeature(PositionEnum.WEBMASTER, position) && (
         <div>
           <Link
             to="/portal/register"

--- a/frontend/src/pages/portal_pages/edit.jsx
+++ b/frontend/src/pages/portal_pages/edit.jsx
@@ -8,7 +8,7 @@ import { editBrother } from '../../redux/actions/authActions';
 import Navbar from '../../components/NavBar';
 import editStyles from './edit.module.scss';
 
-import { MajorEnum } from '../../../../server/routes/api/util/enums/brother-enums';
+import { MajorEnum } from '../../util/enums/brother-enums';
 
 /**
  * Returns an object of changed fields for currently logged in user

--- a/frontend/src/pages/portal_pages/register.jsx
+++ b/frontend/src/pages/portal_pages/register.jsx
@@ -11,7 +11,7 @@ import {
   MajorEnum,
   PledgeClassEnum,
   PositionEnum,
-} from '../../../../server/routes/api/util/enums/brother-enums';
+} from '../../util/enums/brother-enums';
 
 const Register = (props) => {
   const [name, setName] = useState('');

--- a/frontend/src/util/enums/brother-enums.js
+++ b/frontend/src/util/enums/brother-enums.js
@@ -1,4 +1,4 @@
-const MajorEnum = Object.freeze({
+export const MajorEnum = Object.freeze({
   AEROSPACE: 'Aerospace Engineering',
   BIOMEDICAL: 'Biomedical Engineering',
   CIVIL: 'Civil Engineering',
@@ -12,7 +12,7 @@ const MajorEnum = Object.freeze({
   SOFTWARE: 'Software Engineering',
 });
 
-const PledgeClassEnum = Object.freeze({
+export const PledgeClassEnum = Object.freeze({
   FOUNDING: 'Founding',
   ALPHA: 'Alpha',
   BETA: 'Beta',
@@ -20,7 +20,7 @@ const PledgeClassEnum = Object.freeze({
   DELTA: 'Delta',
 });
 
-const PositionEnum = Object.freeze({
+export const PositionEnum = Object.freeze({
   MEMBER: 'Member',
   PRESIDENT: 'Regent',
   VICE_PRESIDENT: 'Vice Regent',
@@ -38,5 +38,3 @@ const PositionEnum = Object.freeze({
   RISK_MANAGEMENT: 'Risk Management',
   WEBMASTER: 'Webmaster',
 });
-
-module.exports = { MajorEnum, PledgeClassEnum, PositionEnum };

--- a/server/routes/api/brothers/brother.js
+++ b/server/routes/api/brothers/brother.js
@@ -28,11 +28,11 @@ const BrotherSchema = new Schema({
     required: true,
   },
   studentID: {
-    type: Number,
+    type: String,
     required: false, // e-board never kept track of student IDs :)))
   },
   phoneNumber: {
-    type: Number,
+    type: String,
     required: true,
   },
   password: {

--- a/server/routes/api/util/scripts/actives-example.js
+++ b/server/routes/api/util/scripts/actives-example.js
@@ -1,0 +1,22 @@
+const {
+  MajorEnum,
+  PledgeClassEnum,
+  PositionEnum,
+} = require('../enums/brother-enums');
+
+const actives = [
+  {
+    name: 'Webmaster Admin',
+    email: 'sjsuthetatauwebmaster@gmail.com',
+    studentID: '123456789',
+    phoneNumber: '0123456789',
+    major: MajorEnum.SOFTWARE,
+    graduatingYear: 9999,
+    pledgeClass: PledgeClassEnum.FOUNDING,
+    position: PositionEnum.WEBMASTER,
+    isGraduated: true,
+  },
+  // more bruh info
+];
+
+module.exports = actives;

--- a/server/routes/api/util/scripts/seed-database.js
+++ b/server/routes/api/util/scripts/seed-database.js
@@ -1,0 +1,46 @@
+const actives = require('./actives');
+const Brother = require('../../brothers/brother');
+
+/**
+ * Populates the DB with information from actives/alumni files
+ */
+const seedDB = () => {
+  Brother.deleteMany(
+    { email: { $ne: 'sjsuthetatauwebmaster@gmail.com' } },
+    (error) => {
+      if (error) {
+        console.error('Error:', error);
+      } else {
+        console.log('Removed all members from DB excluding Webmaster Admin');
+      }
+    }
+  );
+
+  actives.forEach((activeBrother) => {
+    const s3FilePath = activeBrother.studentID
+      ? `${activeBrother.pledgeClass}/${activeBrother.studentID}.jpg`
+      : `${activeBrother.pledgeClass}/${activeBrother.phoneNumber}.jpg`;
+
+    const newBrother = new Brother({
+      name: activeBrother.name,
+      email: activeBrother.email,
+      studentID: activeBrother.studentID ? activeBrother.studentID : null,
+      phoneNumber: activeBrother.phoneNumber,
+      password: `${activeBrother.pledgeClass}-${activeBrother.graduatingYear}`,
+      major: activeBrother.major,
+      graduatingYear: activeBrother.graduatingYear,
+      pledgeClass: activeBrother.pledgeClass,
+      position: activeBrother.position,
+      isGraduated: activeBrother.isGraduated,
+      biography: '',
+      imagePath: s3FilePath,
+    });
+
+    newBrother
+      .save()
+      .then((storedBrother) => console.log(`${storedBrother.name} added to DB`))
+      .catch((error) => console.error('Error:', error));
+  });
+};
+
+module.exports = seedDB;

--- a/server/routes/api/util/scripts/seed-database.js
+++ b/server/routes/api/util/scripts/seed-database.js
@@ -1,4 +1,4 @@
-const actives = require('./actives');
+const actives = require('./actives-example');
 const Brother = require('../../brothers/brother');
 
 /**


### PR DESCRIPTION
Adds a script that can be used to seed the connected MongoDB database when needed. Using an `actives.js` file, this is useful when we need to populate the DB when first deploying the app to production environment. `actives.js` is gitignore'd, `alumni.js` will come soon.

Another PR modifying the `brothers.jsx` page to dynamically render all data from MongoDB/S3 will come after this